### PR TITLE
fix: use default note type when creating folder note from click event

### DIFF
--- a/src/events/handleClick.ts
+++ b/src/events/handleClick.ts
@@ -24,7 +24,7 @@ export async function handleViewHeaderClick(event: MouseEvent, plugin: FolderNot
 		return openFolderNote(plugin, folderNote, event);
 	} else if (event.altKey || Keymap.isModEvent(event) === 'tab') {
 		if ((plugin.settings.altKey && event.altKey) || (plugin.settings.ctrlKey && Keymap.isModEvent(event) === 'tab')) {
-			await createFolderNote(plugin, folderPath, true, undefined, true);
+			await createFolderNote(plugin, folderPath, true, plugin.settings.folderNoteType, true);
 			addCSSClassToTitleEL(folderPath, 'has-folder-note');
 			removeCSSClassFromEL(folderPath, 'has-not-folder-note');
 			return;
@@ -68,7 +68,7 @@ export async function handleFolderClick(event: MouseEvent, plugin: FolderNotesPl
 		}
 	} else if (event.altKey || Keymap.isModEvent(event) === 'tab') {
 		if ((plugin.settings.altKey && event.altKey) || (plugin.settings.ctrlKey && Keymap.isModEvent(event) === 'tab')) {
-			await createFolderNote(plugin, folderPath, true, undefined, true);
+			await createFolderNote(plugin, folderPath, true, plugin.settings.folderNoteType, true);
 			addCSSClassToTitleEL(folderPath, 'has-folder-note');
 			removeCSSClassFromEL(folderPath, 'has-not-folder-note');
 			return;


### PR DESCRIPTION
The click event handlers would call `createFolderNote` with an undefined `extension` parameter, which will ultimately lead to the specified Template not being applied due to a mismatch between the actually created and specified file extensions here: https://github.com/LostPaul/obsidian-folder-notes/blob/945c25f97e0fe64c5a5140a6a6f6c719814f5320/src/functions/folderNoteFunctions.ts#L112

This change explicitly sets the extension parameter to whatever is specified in the settings as default, to prevent that error from happening.

I have tested this fix locally and it seems to work!