### PR TITLE
Escape folder path in selectors

### DIFF
--- a/src/folderOverview/FolderOverview.ts
+++ b/src/folderOverview/FolderOverview.ts
@@ -409,7 +409,7 @@ export class FolderOverview {
     }
 
     getElFromOverview(path: string): HTMLElement | null {
-        const el = this.listEl.querySelector(`[data-path="${path}"]`) as HTMLElement | null;
+        const el = this.listEl.querySelector(`[data-path="${CSS.escape(path)}"]`) as HTMLElement | null;
         return el;
     }
 

--- a/src/functions/styleFunctions.ts
+++ b/src/functions/styleFunctions.ts
@@ -125,7 +125,7 @@ export async function addCSSClassToTitleEL(path: string, cssClass: string, plugi
         return;
     }
     fileExplorerItem.addClass(cssClass);
-    const viewHeaderItems = document.querySelectorAll(`[data-path="${path}"]`);
+    const viewHeaderItems = document.querySelectorAll(`[data-path="${CSS.escape(path)}"]`);
     viewHeaderItems.forEach((item) => {
         item.addClass(cssClass);
     });
@@ -134,7 +134,7 @@ export async function addCSSClassToTitleEL(path: string, cssClass: string, plugi
 export function removeCSSClassFromEL(path: string | undefined, cssClass: string, plugin: FolderNotesPlugin) {
     if (!path) return;
     const fileExplorerItem = getEl(path, plugin);
-    const viewHeaderItems = document.querySelectorAll(`[data-path="${path}"]`);
+    const viewHeaderItems = document.querySelectorAll(`[data-path="${CSS.escape(path)}"]`);
     viewHeaderItems.forEach((item) => {
         item.removeClass(cssClass);
     });


### PR DESCRIPTION
## Summary

Escape path as it can contain unsafe characters that would create an invalid selector.
If this happens, the plug fails to activate.

See docs on the `CSS.escape`: https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static

Error:
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/6b7bf481-d95f-40bc-994b-3020dd482d8e" />


Console example of escaped path:

<img width="225" alt="image" src="https://github.com/user-attachments/assets/1e262813-dfb1-4409-9b85-7e6c51490b93" />

Plugin not active, but selector is valid:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/4914d9a6-04fe-4e96-a12d-60d1f1ee9ccd" />

