### PR TITLE
fix: increase infinity scroll buffer to show hidden folder notes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {
 	refreshAllFolderStyles, setActiveFolder, removeActiveFolder,
 } from './functions/styleFunctions';
 import { getExcludedFolder } from './ExcludeFolders/functions/folderFunctions';
+import { getFileExplorer } from './functions/utils';
 import { FOLDER_OVERVIEW_VIEW, FolderOverviewView } from './obsidian-folder-overview/src/view';
 import { registerOverviewCommands } from './obsidian-folder-overview/src/Commands';
 import { updateOverviewView, updateViewDropdown } from './obsidian-folder-overview/src/main';
@@ -174,6 +175,13 @@ export default class FolderNotesPlugin extends Plugin {
 		}
 
 		registerFileExplorerObserver(this);
+
+		const fileExplorer = getFileExplorer(this);
+		if (fileExplorer) {
+			// @ts-expect-error use internal API
+			fileExplorer.view.tree.infinityScroll.rootMargin = 1.5;
+		}
+
 		this.registerView(FOLDER_OVERVIEW_VIEW, (leaf: WorkspaceLeaf) => {
 			return new FolderOverviewView(leaf, this);
 		});


### PR DESCRIPTION
When Hide Folder Note is enabled, Obsidian's virtual scroll buffer (rootMargin) becomes too small to pre-render items below the many hidden folder notes, causing items to disappear during scrolling.

Increase infinityScroll.rootMargin to 1.5x viewport height to ensure items are pre-rendered even with many hidden items above them.

Closes #274