### PR TITLE
Bug Fix #330 & #332

### DIFF
--- a/src/events/MutationObserver.ts
+++ b/src/events/MutationObserver.ts
@@ -202,7 +202,7 @@ async function updateFolderNamesInPath(
 				viewHeaderTitle.classList.remove('path-is-folder-note');
 			}
 		}
-		if (!folderNote) return;
+		if (!folderNote) continue;
 		if (folderNote) breadcrumb.classList.add('has-folder-note');
 		breadcrumb?.setAttribute('data-path', path.slice(0, -TRAILING_SLASH_LENGTH));
 		if (!breadcrumb.onclick) {

--- a/src/events/MutationObserver.ts
+++ b/src/events/MutationObserver.ts
@@ -202,8 +202,12 @@ async function updateFolderNamesInPath(
 				viewHeaderTitle.classList.remove('path-is-folder-note');
 			}
 		}
-		if (!folderNote) continue;
-		if (folderNote) breadcrumb.classList.add('has-folder-note');
+		if (!folderNote) {
+			breadcrumb.classList.remove('has-folder-note');
+			breadcrumb.removeAttribute('data-path');
+			continue;
+		}
+		breadcrumb.classList.add('has-folder-note');
 		breadcrumb?.setAttribute('data-path', path.slice(0, -TRAILING_SLASH_LENGTH));
 		if (!breadcrumb.onclick) {
 			breadcrumb.addEventListener('click', (e) => {


### PR DESCRIPTION
In the breadcrumb path processing loop, the function exits too early when it encounters a level without a folder note, so later levels are never checked. Because of this early return, clicking a deeper path segment does not open its folder note unless all ancestor folders also have folder notes.