### PR TITLE
Yet Another Expose Public API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,51 @@
+import { TFile, TFolder } from 'obsidian';
+import type FolderNotesPlugin from './main';
+import { getFolderNote, turnIntoFolderNote } from './functions/folderNoteFunctions';
+
+export interface ConvertNoteToFolderNoteOptions {
+	skipConfirmation?: boolean;
+}
+
+export interface FolderNotesApi {
+	convertNoteToFolderNote(notePath: string, options?: ConvertNoteToFolderNoteOptions): Promise<void>;
+}
+
+export class FolderNotesApiPathError extends Error {
+	constructor(
+		message: string,
+		readonly notePath: string,
+	) {
+		super(message);
+		this.name = 'FolderNotesApiPathError';
+	}
+}
+
+export class FolderNotesPublicApi implements FolderNotesApi {
+	constructor(private readonly plugin: FolderNotesPlugin) {}
+
+	async convertNoteToFolderNote(
+		notePath: string,
+		options: ConvertNoteToFolderNoteOptions = {},
+	): Promise<void> {
+		const file = this.plugin.app.vault.getAbstractFileByPath(notePath);
+		if (!(file instanceof TFile)) {
+			throw new FolderNotesApiPathError(`No note exists at path: ${notePath}`, notePath);
+		}
+
+		const folder = file.parent;
+		if (!(folder instanceof TFolder) || folder.path === '' || folder.path === '/') {
+			throw new FolderNotesApiPathError(`Note must be inside a folder: ${notePath}`, notePath);
+		}
+
+		const folderNote = getFolderNote(this.plugin, folder.path);
+		if (folderNote === file) return;
+
+		await turnIntoFolderNote(
+			this.plugin,
+			file,
+			folder,
+			folderNote,
+			options.skipConfirmation ?? true,
+		);
+	}
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,45 @@
 import { TFile, TFolder } from 'obsidian';
 import type FolderNotesPlugin from './main';
 import { getFolderNote, turnIntoFolderNote } from './functions/folderNoteFunctions';
+import { getDetachedFolder, getExcludedFolder } from './ExcludeFolders/functions/folderFunctions';
+
+const API_VERSION = '1.0.0';
 
 export interface ConvertNoteToFolderNoteOptions {
 	skipConfirmation?: boolean;
 }
 
+/**
+ * Public API exposed by the folder-notes plugin on its instance as `plugin.api`.
+ *
+ * External plugins can access it via:
+ *   app.plugins.plugins['folder-notes']?.api
+ *
+ * The API is available after folder-notes has finished onload (settings loaded).
+ */
 export interface FolderNotesApi {
+	/** Semver-ish version string for feature detection. */
+	version: string;
+
+	/**
+	 * Returns the folder note TFile for the given folder path only if the
+	 * folder's note is enabled — i.e., the folder is not detached and not
+	 * excluded with `disableFolderNote`. Matches the plugin's own UI
+	 * gating (the rules that decide whether `.has-folder-note` gets
+	 * applied in the file explorer).
+	 *
+	 * Returns null if:
+	 *   - the folder does not exist or has no folder note
+	 *   - the folder is detached
+	 *   - the folder is excluded with disableFolderNote
+	 */
+	getEnabledFolderNote(folderPath: string): TFile | null;
+
+	/**
+	 * Converts an existing note into the folder note for its parent folder.
+	 * Throws FolderNotesApiPathError if the path does not point to a note
+	 * inside a non-root folder.
+	 */
 	convertNoteToFolderNote(notePath: string, options?: ConvertNoteToFolderNoteOptions): Promise<void>;
 }
 
@@ -20,32 +53,46 @@ export class FolderNotesApiPathError extends Error {
 	}
 }
 
-export class FolderNotesPublicApi implements FolderNotesApi {
-	constructor(private readonly plugin: FolderNotesPlugin) {}
+export function getApi(plugin: FolderNotesPlugin): FolderNotesApi {
+	return {
+		version: API_VERSION,
+		getEnabledFolderNote: (folderPath) => getEnabledFolderNote(plugin, folderPath),
+		convertNoteToFolderNote: (notePath, options) => convertNoteToFolderNote(plugin, notePath, options),
+	};
+}
 
-	async convertNoteToFolderNote(
-		notePath: string,
-		options: ConvertNoteToFolderNoteOptions = {},
-	): Promise<void> {
-		const file = this.plugin.app.vault.getAbstractFileByPath(notePath);
-		if (!(file instanceof TFile)) {
-			throw new FolderNotesApiPathError(`No note exists at path: ${notePath}`, notePath);
-		}
+function getEnabledFolderNote(plugin: FolderNotesPlugin, folderPath: string): TFile | null {
+	const note = getFolderNote(plugin, folderPath);
+	if (!note) return null;
+	if (getDetachedFolder(plugin, folderPath)) return null;
+	const excluded = getExcludedFolder(plugin, folderPath, true);
+	if (excluded?.disableFolderNote) return null;
+	return note;
+}
 
-		const folder = file.parent;
-		if (!(folder instanceof TFolder) || folder.path === '' || folder.path === '/') {
-			throw new FolderNotesApiPathError(`Note must be inside a folder: ${notePath}`, notePath);
-		}
-
-		const folderNote = getFolderNote(this.plugin, folder.path);
-		if (folderNote === file) return;
-
-		await turnIntoFolderNote(
-			this.plugin,
-			file,
-			folder,
-			folderNote,
-			options.skipConfirmation ?? true,
-		);
+async function convertNoteToFolderNote(
+	plugin: FolderNotesPlugin,
+	notePath: string,
+	options: ConvertNoteToFolderNoteOptions = {},
+): Promise<void> {
+	const file = plugin.app.vault.getAbstractFileByPath(notePath);
+	if (!(file instanceof TFile)) {
+		throw new FolderNotesApiPathError(`No note exists at path: ${notePath}`, notePath);
 	}
+
+	const folder = file.parent;
+	if (!(folder instanceof TFolder) || folder.path === '' || folder.path === '/') {
+		throw new FolderNotesApiPathError(`Note must be inside a folder: ${notePath}`, notePath);
+	}
+
+	const folderNote = getFolderNote(plugin, folder.path);
+	if (folderNote === file) return;
+
+	await turnIntoFolderNote(
+		plugin,
+		file,
+		folder,
+		folderNote,
+		options.skipConfirmation ?? true,
+	);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { TFile, TFolder } from 'obsidian';
 import type FolderNotesPlugin from './main';
-import { getFolderNote, turnIntoFolderNote } from './functions/folderNoteFunctions';
+import { getFolderNote, createFolderNote } from './functions/folderNoteFunctions';
 import { getDetachedFolder, getExcludedFolder } from './ExcludeFolders/functions/folderFunctions';
 
 const API_VERSION = '1.0.0';
@@ -80,19 +80,35 @@ async function convertNoteToFolderNote(
 		throw new FolderNotesApiPathError(`No note exists at path: ${notePath}`, notePath);
 	}
 
-	const folder = file.parent;
-	if (!(folder instanceof TFolder) || folder.path === '' || folder.path === '/') {
-		throw new FolderNotesApiPathError(`Note must be inside a folder: ${notePath}`, notePath);
+	const parentFolder = file.parent;
+	if (!(parentFolder instanceof TFolder) || parentFolder.path === '' || parentFolder.path === '/') {
+		throw new FolderNotesApiPathError(`Note must be inside a non-root folder: ${notePath}`, notePath);
 	}
 
-	const folderNote = getFolderNote(plugin, folder.path);
-	if (folderNote === file) return;
+	// Build the new folder path: sibling folder named after the note's basename
+	const newFolderPath = parentFolder.path === ''
+		? file.basename
+		: `${parentFolder.path}/${file.basename}`;
 
-	await turnIntoFolderNote(
-		plugin,
-		file,
-		folder,
-		folderNote,
-		options.skipConfirmation ?? true,
-	);
+	if (plugin.app.vault.getAbstractFileByPath(newFolderPath)) {
+		throw new FolderNotesApiPathError(`A folder already exists at: ${newFolderPath}`, notePath);
+	}
+
+	// Temporarily disable autoCreate to avoid the plugin auto-creating a folder note on folder creation
+	const previousAutoCreate = plugin.settings.autoCreate;
+	plugin.settings.autoCreate = false;
+	void plugin.saveSettings();
+
+	await plugin.app.vault.createFolder(newFolderPath);
+	const newFolder = plugin.app.vault.getAbstractFileByPath(newFolderPath);
+	if (!(newFolder instanceof TFolder)) {
+		plugin.settings.autoCreate = previousAutoCreate;
+		void plugin.saveSettings();
+		throw new FolderNotesApiPathError(`Failed to create folder at: ${newFolderPath}`, notePath);
+	}
+
+	await createFolderNote(plugin, newFolder.path, false, '.' + file.extension, false, file);
+
+	plugin.settings.autoCreate = previousAutoCreate;
+	void plugin.saveSettings();
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -39,6 +39,8 @@ export interface FolderNotesApi {
 	 * Converts an existing note into the folder note for its parent folder.
 	 * Throws FolderNotesApiPathError if the path does not point to a note
 	 * inside a non-root folder.
+	 * Throws FolderNotesApiAlreadyFolderNoteError if the note is already
+	 * a folder note (e.g. aa/aa.md).
 	 */
 	convertNoteToFolderNote(notePath: string, options?: ConvertNoteToFolderNoteOptions): Promise<void>;
 }
@@ -50,6 +52,13 @@ export class FolderNotesApiPathError extends Error {
 	) {
 		super(message);
 		this.name = 'FolderNotesApiPathError';
+	}
+}
+
+export class FolderNotesApiAlreadyFolderNoteError extends Error {
+	constructor(readonly notePath: string) {
+		super(`Note is already a folder note: ${notePath}`);
+		this.name = 'FolderNotesApiAlreadyFolderNoteError';
 	}
 }
 
@@ -83,6 +92,11 @@ async function convertNoteToFolderNote(
 	const parentFolder = file.parent;
 	if (!(parentFolder instanceof TFolder) || parentFolder.path === '' || parentFolder.path === '/') {
 		throw new FolderNotesApiPathError(`Note must be inside a non-root folder: ${notePath}`, notePath);
+	}
+
+	// Guard: already a folder note (e.g. aa/aa.md)
+	if (getFolderNote(plugin, parentFolder.path) === file) {
+		throw new FolderNotesApiAlreadyFolderNoteError(notePath);
 	}
 
 	// Build the new folder path: sibling folder named after the note's basename

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ import { registerOverviewCommands } from './obsidian-folder-overview/src/Command
 import { updateOverviewView, updateViewDropdown } from './obsidian-folder-overview/src/main';
 import { FvIndexDB } from './obsidian-folder-overview/src/utils/IndexDB';
 import { updateAllOverviews } from './obsidian-folder-overview/src/utils/functions';
+import { FolderNotesPublicApi, type FolderNotesApi } from './api';
 
 interface FileExplorerPluginLike extends Plugin {
 	revealInFolder: (file: TAbstractFile) => void;
@@ -88,6 +89,7 @@ export default class FolderNotesPlugin extends Plugin {
 	settingsOpened = false;
 	askModalCurrentlyOpen = false;
 	fvIndexDB!: FvIndexDB;
+	api!: FolderNotesApi;
 
 	async onload(): Promise<void> {
 		console.debug('loading folder notes plugin');
@@ -95,6 +97,7 @@ export default class FolderNotesPlugin extends Plugin {
 		this.settingsTab = new SettingsTab(this.app, this);
 		this.addSettingTab(this.settingsTab);
 		await this.saveSettings();
+		this.api = new FolderNotesPublicApi(this);
 		this.fvIndexDB = new FvIndexDB(this);
 
 		// Add CSS Classes

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import { registerOverviewCommands } from './obsidian-folder-overview/src/Command
 import { updateOverviewView, updateViewDropdown } from './obsidian-folder-overview/src/main';
 import { FvIndexDB } from './obsidian-folder-overview/src/utils/IndexDB';
 import { updateAllOverviews } from './obsidian-folder-overview/src/utils/functions';
-import { FolderNotesPublicApi, type FolderNotesApi } from './api';
+import { getApi, type FolderNotesApi } from './api';
 
 interface FileExplorerPluginLike extends Plugin {
 	revealInFolder: (file: TAbstractFile) => void;
@@ -97,7 +97,7 @@ export default class FolderNotesPlugin extends Plugin {
 		this.settingsTab = new SettingsTab(this.app, this);
 		this.addSettingTab(this.settingsTab);
 		await this.saveSettings();
-		this.api = new FolderNotesPublicApi(this);
+		this.api = getApi(this);
 		this.fvIndexDB = new FvIndexDB(this);
 
 		// Add CSS Classes


### PR DESCRIPTION
Hi, I'm trying to write a script to create a new note in a specified folder—and also **support selecting a specific note, converting it into a folder note, and then moving it into the corresponding FolderNote Folder.**

Currently, FN does not expose an API. If I want to reimplement it from scratch, I would need to reconfigure various relative paths, file naming conventions, template files, and so on. 
Rather than reinventing the wheel, reusing FN's functionality should provide better consistency. 🤔

Also, I noticed that #324 has submitted a PR for a Public API. Our required functions are different, but to avoid conflicts, I have also included their methods.

Hope you could consider it, and again, thank you for building this amazing plugin! <3
